### PR TITLE
remove test from build job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,20 +118,6 @@ jobs:
       run: |
         docker build -t vgc-website:latest .
 
-    - name: Test Docker image
-      run: |
-        docker run --rm -d -p 8000:8000 --name test-container \
-          -e SECRET_KEY="test-key" \
-          -e DEBUG="False" \
-          -e DB_NAME="sqlite" \
-          vgc-website:latest
-        sleep 5
-        # Run migrations in the test container
-        docker exec test-container python manage.py migrate --noinput
-        sleep 5
-        curl -f http://localhost:8000/health/ || curl -f http://localhost:8000 || exit 1
-        docker stop test-container
-
     - name: Deploy to CapRover
       uses: caprover/deploy-from-github@v1.1.2
       with:


### PR DESCRIPTION
This pull request simplifies the deployment workflow by removing the step that tests the Docker image before deployment.

### Deployment workflow changes:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L121-L134): Removed the "Test Docker image" step, which included running the Docker container, applying migrations, and performing health checks, to streamline the deployment process.